### PR TITLE
Error handling for truncated lines

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,17 @@
+package tsv
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrTruncatedLine = errors.New("truncated line")
+var ErrInvalidSeparator = errors.New("invalid separator")
+
+type ErrorInvalidFieldType struct {
+	TypeName string
+}
+
+func (e ErrorInvalidFieldType) Error() string {
+	return fmt.Sprintf("unknown field type: %s", e.TypeName)
+}

--- a/reader.go
+++ b/reader.go
@@ -3,7 +3,6 @@ package tsv
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -156,7 +155,7 @@ func (r *Reader) readHeader() (*Header, error) {
 			encodedSeparator := parts[1]
 			sep, err := hex.DecodeString(string(encodedSeparator[2:]))
 			if err != nil {
-				return nil, fmt.Errorf("invalid separator")
+				return nil, ErrInvalidSeparator
 			}
 			header.Separator = sep[0]
 			continue
@@ -203,10 +202,13 @@ func readFieldType(s string) (FieldType, error) {
 			container: container,
 		}, nil
 	}
-	return FieldType{}, fmt.Errorf("unknown field type: %s", s)
+	return FieldType{}, ErrorInvalidFieldType{TypeName: s}
 }
 
 func (r *Reader) readValue(row Row, idx int) (interface{}, error) {
+	if idx >= len(row) {
+		return nil, ErrTruncatedLine
+	}
 	if bytes.Equal(row[idx], r.header.Unset) {
 		return nil, nil
 	}


### PR DESCRIPTION
- Add `ErrTrancatedLine` error constant

- Change existing `fmt.Errorf()` use to 1 error constant and 1 error type

- Add bounds check in `Reader.readValue()` to prevent panic with truncation and return `ErrTrancatedLine` instead

- Modify parser to use a Scanner with a custom split function that doesn't discard newlines so that we can detect EOF before the end of a TSV line (another truncation case that can happen before the end of the last column value is reached - distinct from the bounds check above) in which case, return `ErrTrancatedLine`

- Add `Reader.Read()` unit tests for the above two truncation error conditions

- Rework existing `Reader.Read()` unit test to use the closure-driven test which also checks the number/value of expected errors.