### PR TITLE
Add Reader.WithBufferSize() and rework unit tests

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -30,6 +30,10 @@ func NewParser(r io.Reader) *Parser {
 	}
 }
 
+func (p *Parser) SetBufferSize(bufSize int) {
+	p.scanner.Buffer(make([]byte, bufSize), bufSize)
+}
+
 func splitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil

--- a/reader.go
+++ b/reader.go
@@ -107,6 +107,12 @@ func (r *Reader) OmitEmpty(b bool) *Reader {
 	return r
 }
 
+// WithBufferSize configures the reader with a custom line scanner buffer size.
+func (r *Reader) WithBufferSize(bufSize int) *Reader {
+	r.parser.SetBufferSize(bufSize)
+	return r
+}
+
 // Header returns the log meta-info.
 func (r *Reader) Header() *Header {
 	return r.header


### PR DESCRIPTION
This adds a `Reader.WithBufferSize()` configuration function that calls `Buffer()` on the `bufio.Scanner` in the parser, allowing parsing of large TSV records. The default is a 64K buffer, but zeek has no limitation on TSV colunm value sizes, so we could easily hit `bufio.Scanner: token too long`.

The unit tests have been updated with a case that fails with the default buffer size, and a case that passes with the same input but a larger (configured buffer).

While I was working on the unit tests I realised that my previous implementation of `collectWithErrors` didn't make sense: once we hit an error it should return, not "accumulate errors". Now we have `collectWithError` that returns only a slice of `Records` + `error`, which is both correct and it makes `MakeReadTester()` quite a bit simpler too.

While this is a simple work-around it still requires knowing up front how big the buffer should be. Ideally the parser should be changed to use `bufio.Reader` instead of `bufio.Scanner` but that is a not a trivial change.