### PR TITLE
Rework parser to use bufio.Reader and remove {Set,With}BufferSize

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -107,12 +107,6 @@ func (r *Reader) OmitEmpty(b bool) *Reader {
 	return r
 }
 
-// WithBufferSize configures the reader with a custom line scanner buffer size.
-func (r *Reader) WithBufferSize(bufSize int) *Reader {
-	r.parser.SetBufferSize(bufSize)
-	return r
-}
-
 // Header returns the log meta-info.
 func (r *Reader) Header() *Header {
 	return r.header


### PR DESCRIPTION
@jhgx I had a couple of hours to look into changing the use of `bufio.Scanner` to `bufio.Reader` in the parser (which I mentioned as a long term fix in #4) and it turned out to be way simpler than I expected.

In fact, not only does this PR fully address the issue of Zeek TSV lines having no length limit, but it also would have made #3 way simpler because `bufio.Reader.ReadBytes()` returns a slice _including_ the delimiter (so we can check for truncation).

Summary of the changes:
- Reworked `Parser.Read()` to use `bufio.Reader`
- Removed the `{Set,With}BufferSize()` functions
- Updated the unit tests (removing `bufSize` arguments and the case that expects `bufio.ErrTooLong` since that won't happen any more, but leaving in the giant-record test in place)
- Removed the `Copy` option from the parser since this is always `false` and is not exposed via the `Reader` API

The resulting code is fewer lines, so less code to maintain :grin:

Unit tests all pass, and benchmarking with a 337MB `conn.log` seems to indicate no change in performance:

```console
$ hyperfine './benchmark.scanner < conn.log' './benchmark.reader < conn.log'
Benchmark 1: ./benchmark.scanner < conn.log
  Time (mean ± σ):      5.756 s ±  0.282 s    [User: 5.845 s, System: 0.180 s]
  Range (min … max):    5.271 s …  6.195 s    10 runs
 
Benchmark 2: ./benchmark.reader < conn.log
  Time (mean ± σ):      5.991 s ±  0.186 s    [User: 6.101 s, System: 0.189 s]
  Range (min … max):    5.664 s …  6.321 s    10 runs
 
Summary
  './benchmark.scanner < conn.log' ran
    1.04 ± 0.06 times faster than './benchmark.reader < conn.log'

$ hyperfine './benchmark.scanner < conn.log' './benchmark.reader < conn.log'
Benchmark 1: ./benchmark.scanner < conn.log
  Time (mean ± σ):      5.834 s ±  0.395 s    [User: 5.935 s, System: 0.187 s]
  Range (min … max):    5.348 s …  6.524 s    10 runs
 
Benchmark 2: ./benchmark.reader < conn.log
  Time (mean ± σ):      5.673 s ±  0.213 s    [User: 5.764 s, System: 0.184 s]
  Range (min … max):    5.458 s …  6.231 s    10 runs
 
Summary
  './benchmark.reader < conn.log' ran
    1.03 ± 0.08 times faster than './benchmark.scanner < conn.log'
```

Regarding versioning: #4 technically changed the package API, and this PR reverts that, which feels bad (though, I suspect I'm probably currently the only person relying on that change). How do you feel about tagging `v1.0.0` and then implementing semver?

Finally - please let me know if you'd like help maintaining.
