### PR TITLE
Introduce lazy reader interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go.sum
+cmd/benchmark*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/0xcc-labs/zeek-tsv
 
-require (
-	github.com/francoispqt/gojay v0.0.0-20190228132548-90d953358b68
-	github.com/stretchr/testify v1.3.0 // indirect
-)
+go 1.24.0
+
+require github.com/francoispqt/gojay v0.0.0-20190228132548-90d953358b68
+
+require github.com/stretchr/testify v1.8.1 // indirect

--- a/lazy_reader.go
+++ b/lazy_reader.go
@@ -1,0 +1,57 @@
+package tsv
+
+import (
+	"bytes"
+	"io"
+)
+
+// LazyReader is a zeek tsv file reader that defers type conversions.
+type LazyReader struct {
+	parser     *Parser
+	header     *Header
+	fieldIndex map[string]int
+}
+
+// NewLazyReader creates a new lazy reader.
+func NewLazyReader(r io.Reader) *LazyReader {
+	return &LazyReader{
+		parser: NewParser(r),
+	}
+}
+
+// Header returns the log meta-info.
+func (r *LazyReader) Header() *Header {
+	return r.header
+}
+
+func (r *LazyReader) Read() (*LazyRecord, error) {
+	var row Row
+	var err error
+
+	if r.header == nil {
+		r.header, err = readHeader(r.parser, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		r.fieldIndex = make(map[string]int, len(r.header.Fields))
+		for idx, fieldName := range r.header.Fields {
+			r.fieldIndex[fieldName] = idx
+		}
+
+		row = r.parser.Current()
+	} else {
+		row, err = r.parser.Read()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if bytes.HasPrefix(row[0], []byte("#close")) {
+		return nil, io.EOF
+	}
+
+	return &LazyRecord{
+		lazyReader: r,
+		row:        row,
+	}, nil
+}

--- a/lazy_record.go
+++ b/lazy_record.go
@@ -1,0 +1,79 @@
+package tsv
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type ErrNoSuchField struct {
+	field string
+}
+
+func (e ErrNoSuchField) Error() string {
+	return fmt.Sprintf("no such field: %s", e.field)
+}
+
+type LazyRecord struct {
+	lazyReader *LazyReader
+	row        Row
+}
+
+func (r *LazyRecord) BytesByName(field string) ([]byte, error) {
+	idx, ok := r.lazyReader.fieldIndex[field]
+	if !ok {
+		return nil, ErrNoSuchField{field: field}
+	}
+
+	return r.BytesByIndex(idx)
+}
+
+func (r *LazyRecord) BytesByIndex(idx int) ([]byte, error) {
+	if idx >= len(r.row) {
+		return nil, ErrTruncatedLine
+	}
+	if bytes.Equal(r.row[idx], r.lazyReader.header.Unset) {
+		return nil, nil
+	}
+	if bytes.Equal(r.row[idx], r.lazyReader.header.Empty) {
+		if r.lazyReader.header.Types[idx].IsContainer {
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	return r.row[idx], nil
+}
+
+func (r *LazyRecord) ValueByName(field string) (interface{}, error) {
+	idx, ok := r.lazyReader.fieldIndex[field]
+	if !ok {
+		return nil, ErrNoSuchField{field: field}
+	}
+
+	return r.ValueByIndex(idx)
+}
+
+func (r *LazyRecord) ValueByIndex(idx int) (interface{}, error) {
+	buf, err := r.BytesByIndex(idx)
+	if err != nil {
+		return nil, err
+	}
+	if buf == nil {
+		return nil, nil
+	}
+
+	converter := ValueConverters[r.lazyReader.header.Types[idx].Type]
+	if r.lazyReader.header.Types[idx].IsContainer {
+		parts := bytes.Split(buf, r.lazyReader.header.SetSeparator)
+		res := make([]interface{}, len(parts))
+		for i := 0; i < len(parts); i++ {
+			v, err := converter(parts[i])
+			if err != nil {
+				return nil, err
+			}
+			res[i] = v
+		}
+		return res, nil
+	}
+	return converter(buf)
+}


### PR DESCRIPTION
@jhgx would you mind doing a sanity check on this (relatively big) change?

This adds a new interface: `LazyReader` and corresponding `LazyRecord` which defer type conversions to be on-demand per column via `LazyRecord.ValueByIndex()` or `LazyRecord.ValueByName()`. These methods use the column index or name, respectively to select the desired column.

`ValueByName()` looks up the column index using an internal map built when the header is parsed. I found that linear search was faster than a map lookup (for a log with ~20 columns) until the golang map implementation was changed to swiss tables in Go 1.24, after which the difference went away, hence I have chosen the map approach and `go.mod` now requires 1.24 or greater.

This makes the module more efficient for reading large logs where only a subset of the columns need to be used.

In addition to the above, `LazyRecord` also has `BytesByIndex()` and `BytesByName()` which correspond to the `Value*` equivalents, but do no type conversion and just return the raw column value bytes. These offer an additional speed-up where type conversion isn't needed (a "do less work" optmisation).

There are some other small changes to the existing code:

- I have made the members of `FieldType` public, which is sort-of a bugfix since the `Header.Types` was public but useless. This is an additive change and shouldn't break anything. It isn't needed for the new code, but practical use of the new API in a client application is enabled by being able to inspect column types before reading rows.
- I changed `Reader.readHeader()` from a method to a function so that I can call it from the new `LazyReader` code and avoid duplication.
- Added more tests (which pass :grin:)

If you're happy with this, I propose tagging this `v1.1.0` since it adds new functionality and doesn't break the `v1` API.